### PR TITLE
Move chai/mocha to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   ],
   "author": "Arshad",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "chai": "^4.1.2",
-    "mocha": "^5.0.1",
+    "mocha": "^5.0.1"
+  },
+  "dependencies": {
     "moment": "^2.20.1"
   }
 }


### PR DESCRIPTION
Moved chai/mocha testing frameworks to devDependencies object in package.json. Issue #10.